### PR TITLE
Fixed compilation error for /brute_force/www_brute

### DIFF
--- a/common/curve25519-donna.hpp
+++ b/common/curve25519-donna.hpp
@@ -2,6 +2,7 @@
 #define CURVE25519_DONNA_H
 
 #include <boost/cstdint.hpp>
+#include "curve25519-donna.cpp"
 
 int curve25519_donna(boost::uint8_t* p_pub_key, const boost::uint8_t* p_priv_key,  const boost::uint8_t* p_basepoint);
 


### PR DESCRIPTION
Warning: The tool still gives "Bad decrypt!" errors for some reason!

Compiling the files according to the guidelines gives rise to the error on Ubuntu 20.04 (x64) 5.4.0-29-generic:
gcc version 9.3.0 (Ubuntu 9.3.0-10ubuntu2)

[ 11%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/jsproxy_session.cpp.o
[ 22%] Linking CXX executable www_bruteforce
/usr/bin/ld: CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/jsproxy_session.cpp.o: in function `JSProxySession::JSProxySession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/home/adonizer/Downloads/routeros-master/common/jsproxy_session.cpp:319: undefined reference to `curve25519_donna(unsigned char*, unsigned char const*, unsigned char const*)'
/usr/bin/ld: CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/jsproxy_session.cpp.o: in function `JSProxySession::doPublicKey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)':
/home/adonizer/Downloads/routeros-master/common/jsproxy_session.cpp:408: undefined reference to `curve25519_donna(unsigned char*, unsigned char const*, unsigned char const*)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/www_bruteforce.dir/build.make:192: www_bruteforce] Error 1
make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/www_bruteforce.dir/all] Error 2
make: *** [Makefile:84: all] Error 2

After the fix:

[ 11%] Building CXX object CMakeFiles/www_bruteforce.dir/src/main.cpp.o
[ 22%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/jsproxy_session.cpp.o
[ 33%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/session.cpp.o
[ 44%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/sha1.cpp.o
[ 55%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/md4.cpp.o
[ 66%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/rc4.cpp.o
[ 77%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/des.cpp.o
[ 88%] Building CXX object CMakeFiles/www_bruteforce.dir/home/adonizer/Downloads/routeros-master/common/winbox_message.cpp.o
[100%] Linking CXX executable www_bruteforce
[100%] Built target www_bruteforce